### PR TITLE
Add [un]ordinals gallery

### DIFF
--- a/collections.json
+++ b/collections.json
@@ -11,7 +11,7 @@
     "name": "[un]ordinals",
     "type": "gallery",
     "id": "ef8749da5133f2d127ec4853c6f3079bd19b1f9a8d741e635cdc1f9c4fe58b20i0",
-    "slug": "unordinals"
+    "slug": "the-unordinals"
   },
   {
     "name": "$DOG | Ordinals - SZN I Genesis",


### PR DESCRIPTION
## [un]ordinals

5,000 skeletons across three chapters, unified under one gallery inscription.

**Gallery ID:** `ef8749da5133f2d127ec4853c6f3079bd19b1f9a8d741e635cdc1f9c4fe58b20i0`

| Chapter | Supply | Inscription Range |
|---------|--------|-------------------|
| [un]ordinals | 1,000 | #44713 to #55634 |
| [re]birth | 1,000 | #82346 to #189742 |
| [un]cursed | 3,000 | #-5514 to #-30366 (art) / #-411176 to #-417416 (delegates) |

- Inscribed Feb 2023 (sub-100k numbers)
- Gallery includes full traits per item with Brotli compression
- Replaces legacy ME entries: "Unordinals" (symbol: unordinals) and "Unordinals: Rebirth" (symbol: rebirth)

**Links:** [ordinals.com](https://ordinals.com/inscription/ef8749da5133f2d127ec4853c6f3079bd19b1f9a8d741e635cdc1f9c4fe58b20i0) | [@unordinals](https://x.com/unordinals)

what is dead may never die.