### PR TITLE
Add Planetary Ordinals gallery

### DIFF
--- a/collections.json
+++ b/collections.json
@@ -911,6 +911,12 @@
     "slug": "pizza-ninjas"
   },
   {
+    "name": "Planetary Ordinals",
+    "type": "gallery",
+    "id": "b533f0a73d9a6d15a7761517f32a4a2fd2263b074ada30464c90ad70c3b4377bi0",
+    "slug": "planetary-ordinals"
+  },
+  {
     "name": "Planets",
     "type": "parent",
     "ids": [


### PR DESCRIPTION
## Summary
- Adds Planetary Ordinals as a gallery collection
- Gallery inscription ID: b533f0a73d9a6d15a7761517f32a4a2fd2263b074ada30464c90ad70c3b4377bi0
- One of the first NFT collections ever minted on Ordinals (Inscriptions #463-1103, 69 supply)

## Test plan
- [ ] Verify entry is correctly formatted in collections.json
- [ ] Confirm gallery inscription ID resolves correctly