### PR TITLE
Add Ordinals Wallet to slug conflict check

### DIFF
--- a/.github/workflows/slug-review.yml
+++ b/.github/workflows/slug-review.yml
@@ -55,7 +55,10 @@ jobs:
               const satflow = entry.satflowMatch
                 ? `⚠️ [Yes](${entry.satflowUrl})`
                 : '—';
-              return `| \`${entry.slug}\` | ${legacy} | ${satflow} |`;
+              const ordinalswallet = entry.ordinalswalletMatch
+                ? `⚠️ [Yes](${entry.ordinalswalletUrl})`
+                : '—';
+              return `| \`${entry.slug}\` | ${legacy} | ${satflow} | ${ordinalswallet} |`;
             });
 
             const body = [
@@ -63,8 +66,8 @@ jobs:
               '',
               'The following new slugs conflict with existing listings:',
               '',
-              '| Slug | Legacy (Magic Eden) | Satflow |',
-              '|------|-------------------|---------|',
+              '| Slug | Legacy (Magic Eden) | Satflow | Ordinals Wallet |',
+              '|------|-------------------|---------|-----------------|',
               ...rows,
               '',
               '_This is informational only and does not block merging._',

--- a/scripts/check-slug-conflicts.js
+++ b/scripts/check-slug-conflicts.js
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 
 const BASE_COLLECTIONS_JSON = process.env.BASE_COLLECTIONS_JSON || '[]'
 const SATFLOW_BASE = 'https://www.satflow.com/ordinals'
+const ORDINALSWALLET_BASE = 'https://turbo.ordinalswallet.com/collection'
 
 const baseCollections = JSON.parse(BASE_COLLECTIONS_JSON)
 const baseSlugs = new Set(baseCollections.map(entry => entry.slug))
@@ -37,8 +38,18 @@ for (const slug of newSlugs) {
     // network error — treat as no match
   }
 
-  if (legacyMatch || satflowMatch) {
-    found.push({ slug, legacyMatch, satflowMatch, satflowUrl })
+  let ordinalswalletMatch = false
+  const ordinalswalletUrl = `${ORDINALSWALLET_BASE}/${slug}`
+
+  try {
+    const response = await fetch(ordinalswalletUrl, { method: 'HEAD', redirect: 'follow' })
+    ordinalswalletMatch = response.ok
+  } catch {
+    // network error — treat as no match
+  }
+
+  if (legacyMatch || satflowMatch || ordinalswalletMatch) {
+    found.push({ slug, legacyMatch, satflowMatch, satflowUrl, ordinalswalletMatch, ordinalswalletUrl })
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds turbo.ordinalswallet.com as a third source for slug conflict detection
- HEAD requests to `turbo.ordinalswallet.com/collection/{slug}` alongside existing Legacy and Satflow checks
- Adds Ordinals Wallet column to the PR comment table

## Changes
- `scripts/check-slug-conflicts.js` — added ordinalswallet HEAD check
- `.github/workflows/slug-review.yml` — added Ordinals Wallet column to conflict table