### PR TITLE
Add Pixel Pepes gallery

### DIFF
--- a/collections.json
+++ b/collections.json
@@ -903,6 +903,12 @@
     "slug": "pepelurkers"
   },
   {
+    "name": "Pixel Pepes",
+    "type": "gallery",
+    "id": "80b39fcf004acfd256455caa2a3c1466d2de166f70229778a27342f09b7d4253i0",
+    "slug": "pixel-pepes"
+  },
+  {
     "name": "Pizza Ninjas",
     "type": "parent",
     "ids": [


### PR DESCRIPTION
## Summary

- Adds Pixel Pepes as a gallery collection
- Gallery inscription: `80b39fcf004acfd256455caa2a3c1466d2de166f70229778a27342f09b7d4253i0`
- The first ever airdrop on the Bitcoin network — 1,563 rare Pixel Pepes airdropped to users who transacted on ordinalswallet.com before block 777888